### PR TITLE
Add new Isaac SSH key for MacBook 40

### DIFF
--- a/staff/isaac_lowe_MacBook-Pro-40
+++ b/staff/isaac_lowe_MacBook-Pro-40
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOso37/2JVmUyKXX41v82N4Qwn+vyOMtRssP8jQxpeej isaac@studio24.net


### PR DESCRIPTION
New SSH key for deployment for MacBook 40.