### PR TITLE
Delete staff/miro_ostafinski.pub

### DIFF
--- a/staff/miro_ostafinski.pub
+++ b/staff/miro_ostafinski.pub
@@ -1,1 +1,0 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM9/q1AtN4x+YyiwJwT69LDXYOuYir9vmh3h4lwl821m miro@studio24.net


### PR DESCRIPTION
Removal of Miro's SSH key.

This will automatically propagate across servers via our Ansible servers. 

Please approve and merge at the point we know that Miro no longer requires access to any servers.

Once merged please update the To-do in [Basecamp](https://3.basecamp.com/3091560/buckets/10675628/todos/9330624064)